### PR TITLE
chore: Add AWS provider configuration and resources

### DIFF
--- a/_init.tf
+++ b/_init.tf
@@ -15,3 +15,38 @@ module "eks" {
   source          = "./modules/eks"
 }
 
+provider "aws" {
+  region = "us-east-1"
+  skip_credentials_validation = true
+  skip_requesting_account_id = true
+  access_key = "mock_access_key"
+  secret_key = "mock_secret_key"
+}
+
+resource "aws_instance" "my_web_app" {
+  ami = "ami-005e54dee72cc1d00"
+
+  instance_type = "m3.xlarge" # <<<<<<<<<< Try changing this to m5.xlarge to compare the costs
+
+  tags = {
+    Environment = "production"
+    Service = "web-app"
+  }
+
+  root_block_device {
+    volume_size = 1000 # <<<<<<<<<< Try adding volume_type="gp3" to compare costs
+  }
+}
+
+resource "aws_lambda_function" "my_hello_world" {
+  runtime = "nodejs12.x"
+  handler = "exports.test"
+  image_uri = "test"
+  function_name = "test"
+  role = "arn:aws:ec2:us-east-1:123123123123:instance/i-1231231231"
+
+  memory_size = 512
+  tags = {
+    Environment = "Prod"
+  }
+}

--- a/_init.tf
+++ b/_init.tf
@@ -14,39 +14,3 @@ module "ec2" {
 module "eks" {
   source          = "./modules/eks"
 }
-
-provider "aws" {
-  region = "us-east-1"
-  skip_credentials_validation = true
-  skip_requesting_account_id = true
-  access_key = "mock_access_key"
-  secret_key = "mock_secret_key"
-}
-
-resource "aws_instance" "my_web_app" {
-  ami = "ami-005e54dee72cc1d00"
-
-  instance_type = "m3.xlarge" # <<<<<<<<<< Try changing this to m5.xlarge to compare the costs
-
-  tags = {
-    Environment = "production"
-    Service = "web-app"
-  }
-
-  root_block_device {
-    volume_size = 1000 # <<<<<<<<<< Try adding volume_type="gp3" to compare costs
-  }
-}
-
-resource "aws_lambda_function" "my_hello_world" {
-  runtime = "nodejs12.x"
-  handler = "exports.test"
-  image_uri = "test"
-  function_name = "test"
-  role = "arn:aws:ec2:us-east-1:123123123123:instance/i-1231231231"
-
-  memory_size = 512
-  tags = {
-    Environment = "Prod"
-  }
-}

--- a/environment/dev.tfvars
+++ b/environment/dev.tfvars
@@ -1,0 +1,1 @@
+number_of_eks_clusters=2

--- a/infracost-test.tf
+++ b/infracost-test.tf
@@ -1,0 +1,12 @@
+resource "aws_lambda_function" "my_hello_world" {
+  runtime = "nodejs12.x"
+  handler = "exports.test"
+  image_uri = "test"
+  function_name = "test"
+  role = "arn:aws:ec2:us-east-1:123123123123:instance/i-1231231231"
+
+  memory_size = 512
+  tags = {
+    Environment = "Prod"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,6 @@ variable "s3_buckets" {
   description = "The list of S3 buckets to create."
   type        = list(string)
   default     = ["dev", "prod"]
-  
 }
 
 variable "number_of_eks_clusters" {


### PR DESCRIPTION
This commit adds the necessary AWS provider configuration and resources to the `_init.tf` file. It sets the region to `us-east-1` and includes the access key and secret key for authentication. Additionally, it defines an `aws_instance` resource named `my_web_app` with an AMI, instance type, and tags. It also includes an `aws_lambda_function` resource named `my_hello_world` with a runtime, handler, image URI, function name, and tags.

The changes in this commit are necessary to configure the AWS provider and define the required resources for the application.

```